### PR TITLE
Upgrade rouge to 2.0.6 and try to figure out Gem load problems on Win

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -40,3 +40,10 @@ jrubyPrepare << {
     into sourceSets.main.output.resourcesDir
   }
 }
+test {
+  // Uncomment to see where JRuby loads gems from
+  //systemProperty 'jruby.debug.loadService', 'true'
+  testLogging {
+    showStandardStreams = true
+  }
+}

--- a/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenRougeGemIsRequired.java
+++ b/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenRougeGemIsRequired.java
@@ -1,0 +1,16 @@
+package org.asciidoctor;
+
+import org.asciidoctor.internal.JRubyRuntimeContext;
+import org.junit.Test;
+
+public class WhenRougeGemIsRequired {
+
+    @Test
+    public void itShouldNotFail() {
+
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create((String) null);
+        JRubyRuntimeContext.get().evalScriptlet("require 'rouge'");
+
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '1.5.4.1'
   asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : project(':asciidoctorj-pdf').version.replace('-', '.')
   groovyVersion = '2.1.8'
-  rougeGemVersion = '1.10.1'
+  rougeGemVersion = '2.0.6'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.5'
   ttfunkGemVersion = '1.2.2'


### PR DESCRIPTION
This PR is related to #3 
It updates rouge to the most recent version and adds a test that creates an Asciidoctor and requires the rouge gem to get the original error why rouge cannot be loaded.
