### PR TITLE
Upgrade to asciidoctor-pdf 1.5.0-alpha.15

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -1,20 +1,28 @@
 dependencies {
-  compile "org.asciidoctor:asciidoctorj:$asciidoctorJVersion"
+  compile ("org.asciidoctor:asciidoctorj:$asciidoctorJVersion") {
+    exclude group:'org.jruby'
+  }
 
-  testRuntime "org.jruby:jruby-complete:$jrubyVersion"
+  compile "org.jruby:jruby-complete:$jrubyVersion"
 
-  //provided "org.jruby:jruby-complete:$jrubyVersion"
 
   gems("rubygems:asciidoctor-pdf:$asciidoctorPdfGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
     exclude module: 'thread_safe'
+    // We must lock Prawn to 1.3.0 until AsciidoctorJ upgrades to JRuby 9.0.0.0
+    exclude module: 'prawn'
+    exclude module: 'addressable'
+    exclude module: 'public_suffix'
   }
+  gems "rubygems:thread_safe:$threadSafeGemVersion"
+  
+  gems "rubygems:prawn:$prawnGemVersion"
   gems "rubygems:rouge:$rougeGemVersion"
+  gems "rubygems:addressable:$addressableVersion"
+  gems "rubygems:public_suffix:$public_suffixVersion"
 
   testCompile "org.apache.pdfbox:pdfbox:$pdfboxVersion"
-
-
 }
 
 def gemFiles = fileTree(jruby.gemInstallDir) {

--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
-version=1.5.0-alpha.13
+version=1.5.0-alpha.15
 gem_name=asciidoctor-pdf

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '1.3.0'
+  id 'com.github.jruby-gradle.base' version '1.4.0'
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version
@@ -34,20 +34,23 @@ ext {
   commonsioVersion = '2.4'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
-  jcommanderVersion = '1.35'
-  jrubyVersion = '9.1.5.0'
+  jrubyVersion = '9.1.8.0'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'
   xmlMatchersVersion = '1.0-RC1'
   pdfboxVersion = '1.8.10'
 
   // gem versions
-  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '1.5.4.1'
+  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '1.5.5'
   asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : project(':asciidoctorj-pdf').version.replace('-', '.')
   groovyVersion = '2.1.8'
-  rougeGemVersion = '1.10.1'
+
+  addressableVersion = '2.4.0'
+  public_suffixVersion = '1.4.6'
+  prawnGemVersion='2.2.2'
+  rougeGemVersion = '2.0.7'
   spockVersion = '0.7-groovy-2.0'
-  threadSafeGemVersion = '0.3.5'
+  threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.2.2'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.5.0-alpha.13
+version=1.5.0-alpha.15
 sourceCompatibility=1.7
 targetCompatibility=1.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/itest/build.gradle
+++ b/itest/build.gradle
@@ -1,9 +1,11 @@
 dependencies {
 
-  testCompile "org.asciidoctor:asciidoctorj:$asciidoctorJVersion"
+  testCompile ("org.asciidoctor:asciidoctorj:$asciidoctorJVersion") {
+    exclude group:'org.jruby'
+  }
 
   testRuntime project(':asciidoctorj-pdf')
-  testRuntime 'org.asciidoctor:asciidoctorj-diagram:1.5.0'
+  testRuntime 'org.asciidoctor:asciidoctorj-diagram:1.5.4'
 }
 
 jar.enabled = false


### PR DESCRIPTION
This PR updates asciidoctor-pdf to the latest version 1.5.0-alpha.15.

Notable change that I had to do is upgrade thread_safe to 0.3.6.
It seems to run fine though with two versions on the class path, 0.3.5 from asciidoctorj and 0.3.6 from asciidoctorj-pdf.