### PR TITLE
include text-hyphen gem to allow hyphenation in upcoming asciidoctor-pdf 1.5.x

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   testCompile "org.jruby:jruby-complete:$jrubyVersion"
 
 
-  gems("rubygems:asciidoctor-pdf:1.5.0.beta.7") {
+  gems("rubygems:asciidoctor-pdf:1.5.0.beta.8") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
     exclude module: 'thread_safe'
@@ -21,6 +21,7 @@ dependencies {
   gems "rubygems:rouge:$rougeGemVersion"
   gems "rubygems:addressable:$addressableVersion"
   gems "rubygems:public_suffix:$public_suffixVersion"
+  gems "rubygems:text-hyphen:$textHyphenVersion"
 
   testCompile "org.apache.pdfbox:pdfbox:$pdfboxVersion"
 }

--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
-version=1.5.0-beta.7
+version=1.5.0-beta.8
 gem_name=asciidoctor-pdf

--- a/asciidoctorj-pdf/src/test/resources/hyphenation-de-sample.adoc
+++ b/asciidoctorj-pdf/src/test/resources/hyphenation-de-sample.adoc
@@ -1,0 +1,5 @@
+:hyphens: DE
+
+Mitwirkende sind immer willkommen.
+Neue Mitwirkende sind immer willkommen!
+Wenn Sie Fehler oder Auslassungen im Quellcode, in der Dokumentation oder im Inhalt der Website entdecken, zögern Sie bitte nicht, ein Problem zu melden oder eine Pull Request mit einem Fix zu öffnen.

--- a/asciidoctorj-pdf/src/test/resources/hyphenation-en-sample.adoc
+++ b/asciidoctorj-pdf/src/test/resources/hyphenation-en-sample.adoc
@@ -1,0 +1,3 @@
+:hyphens:
+
+This story chronicles the inexplicable hazards and vicious beasts a team must conquer and vanquish on the journey to discover the true power of Open Source.

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   commonsioVersion = '2.4'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
-  jrubyVersion = '9.1.12.0'
+  jrubyVersion = '9.1.17.0'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'
   xmlMatchersVersion = '1.0-RC1'
@@ -52,6 +52,7 @@ ext {
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.2.2'
+  textHyphenVersion='1.4.1'
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.5.0-beta.7
+version=1.5.0-beta.8
 sourceCompatibility=1.7
 targetCompatibility=1.7


### PR DESCRIPTION
to allow users to switch on hyphenation of created PDF.

This is added as part of https://github.com/asciidoctor/asciidoctor-pdf/issues/20 and will be part of an upcoming asciidoctor-pdf 1.5.x release.

It is an optional dependency for the gem, but IMHO it would be nice for users of AsciidoctorJ-PDF to have these 700k already included in the 4000k JAR to avoid manual configuration for the users.

