### PR TITLE
Add badge to README. Don't built on Java11

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,8 +17,9 @@ jobs:
       matrix:
         java:
           - '1.8'
-          - '11'
           - '1.7'
+          # Disable Java11 because Gradle doesn't run with it...
+          #- '11'
         os:
           - ubuntu-latest
           - macos-latest

--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 // TODO: Fix URLs for badges once CI is configured
 ifdef::badges[]
 image:https://img.shields.io/travis/asciidoctor/asciidoctorj/master.svg[Build Status (Travis CI), link=https://travis-ci.org/asciidoctor/asciidoctorj-pdf]
+image:https://github.com/asciidoctor/asciidoctorj-pdf/workflows/Build%20Master/badge.svg?event=push[Build Status (Github Actions)]
 endif::[]
 
 ifdef::awestruct,env-browser[]


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

[X] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

What is the goal of this pull request?

Add badge to README.
Fix CI build.

How does it achieve that?

Fix CI build by no longer building on Java11 which isn't support by our current Gradle version.

Are there any alternative ways to implement this?

Update Gradle, but that's for later.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

No issue.

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc