### PR TITLE
don't make build fail on outdated sources for mongodb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script: unset GEM_PATH GEM_HOME JRUBY_OPTS
 before_install:
   - sudo hostname "$(hostname | cut -c1-63)"
   - (cat /etc/hosts ; echo 127.0.0.1 $(hostname)) | sudo tee /etc/hosts
+  - sudo rm /etc/apt/sources.list.d/mongodb.list # URL is broken in precise, doesn't work any more
   - sudo apt-get -qq update
   - sudo apt-get install -y graphviz
 install: ./gradlew -S -Pskip.signing assemble
@@ -17,5 +18,7 @@ notifications:
   irc:
     channels:
       - "irc.freenode.org#asciidoctor"
+    # don't notify on forked repositories
+    if: repo = asciidoctor/asciidoctorj-pdf
 env:
   - secure: "WYU2AptOM6CIiIykVUCj2Ca4umapAl2Qxv8sQDDTNuv9gVHk1rtU42kD6oqS/YoID0QoPy8g6Ggyvy1MF0wMpL4Vvu8pLnbLiYoJtmecpLHB0UZ1UixsgWL7bHExrh+ciCjjqliN9C0rUnmiDHj9Ald2VSWH6Vvcl2YG67Pbl+c="

--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ subprojects {
     }
 
     testLogging {
+      exceptionFormat = 'full'
       // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
       // events 'standard_out', 'standard_error'
       afterSuite { desc, result ->


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[x] Build improvement

## Description

**What is the goal of this pull request?**
Make build run on Travis again

**How does it achieve that?**
There was a mongo db repo that wasn't reachable any more, and apt-get didn't reach it.

**Are there any alternative ways to implement this?**
Maybe there could have been a selective apt-get statement, or to just ignore the error; two options that I dismissed.

**Are there any implications of this pull request? Anything a user must know?**
The build still fails in a later step: while the local "check" succeeds, test-asciidoctor-upstream.sh now fails. This is unrelated.

**Other**
The failed tests are written to the console in more detail. Builds in other repos don't notify the IRC channel any more.

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
(none)