### PR TITLE
Upgrade jruby-gradle-plugin to 2.0.0-alpha.7 and gradle to 5.6.3

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,17 +17,13 @@ jobs:
       matrix:
         java:
           - '1.8'
-          - '1.7'
-          # Disable Java11 because Gradle doesn't run with it...
-          #- '11'
+          - '11.0.5'
         os:
           - ubuntu-latest
           - macos-latest
         exclude:
           - os: macos-latest
             java: '1.8'
-          - os: macos-latest
-            java: '1.7'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   testCompile "org.apache.pdfbox:pdfbox:$pdfboxVersion"
 }
 
-def gemFiles = fileTree(jruby.gemInstallDir) {
+def gemFiles = fileTree("${project.buildDir}/.gems") {
   include 'specifications/*.gemspec'
   include 'gems/*/lib/**'
   include "gems/*/data/fonts/**"
@@ -45,9 +45,11 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   exclude 'gems/rouge-*/lib/rouge/demos/**'
 }
 
-jrubyPrepare << {
-  copy { // bundles the gems inside this artifact
-    from gemFiles
-    into sourceSets.main.output.resourcesDir
+jrubyPrepare {
+  doLast {
+    copy { // bundles the gems inside this artifact
+      from gemFiles
+      into preparedGems
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
     }
 }
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '1.4.0'
+  id 'com.github.jruby-gradle.base' version '2.0.0-alpha.7'
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version
@@ -143,14 +143,7 @@ configure(subprojects.findAll {it.name != 'itest'}) {
   apply plugin: 'com.github.jruby-gradle.base'
 
   repositories {
-    maven {
-      name 'rubygems-release'
-      url 'http://rubygems-proxy.torquebox.org/releases'
-    }
-    maven {
-      name 'rubygems-prerelease'
-      url 'http://rubygems-proxy.torquebox.org/prereleases'
-    }
+    ruby.gems()
   }
 
   if (JavaVersion.current().isJava8Compatible()) {
@@ -159,15 +152,26 @@ configure(subprojects.findAll {it.name != 'itest'}) {
       options.addStringOption('Xdoclint:none', '-quiet')
     }
   }
+
+  ext {
+    // path to use for the prepared jruby gems
+    preparedGems = new File("$buildDir/preparedGems")
+  }
+
+  sourceSets {
+    main {
+      //let's register an output folder on the main SourceSet:
+      output.dir(preparedGems, builtBy: 'jrubyPrepare')
+      //it is now a part of the 'main' classpath and will be a part of the jar
+    }
+  }
+
 }
 
 configure(subprojects.findAll { it.name != 'itest'}) {
 
   jruby {
-    defaultRepositories = false
-    defaultVersion = jrubyVersion
-    execVersion = jrubyVersion
-    // TODO I'd like to be able to customize the name of the gemInstallDir
+    jrubyVersion = jrubyVersion
   }
 
   // QUESTION is this the right place to insert this task dependency in the lifecycle?

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -109,8 +109,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[X] Build improvement

## Description

Similar to asciidoctor/asciidoctorj#885 this PR upgrades the jruby-gradle-plugin to 2.0.0-alpha.7.
It is also necessary to update gradle to 5.6.3 as gradle 2 doesn't seem to be supported anymore.