### PR TITLE
Set version of ttfunk gem to 1.5.1

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     exclude module: 'prawn'
     exclude module: 'addressable'
     exclude module: 'public_suffix'
+    exclude module: 'ttfunk'
   }
   gems "rubygems:thread_safe:$threadSafeGemVersion"
   
@@ -23,6 +24,7 @@ dependencies {
   gems "rubygems:addressable:$addressableVersion"
   gems "rubygems:public_suffix:$public_suffixVersion"
   gems "rubygems:text-hyphen:$textHyphenVersion"
+  gems "rubygems:ttfunk:$ttfunkGemVersion"
 
   testCompile "org.apache.pdfbox:pdfbox:$pdfboxVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
   rougeGemVersion = '3.13.0'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
-  ttfunkGemVersion = '1.2.2'
+  ttfunkGemVersion = '1.5.1'
   textHyphenVersion='1.4.1'
 }
 


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description
Apparently ttfunk just released a new version 1.6.0 that is incompatible with the previous version 1.5.1.
As the current version of asciidoctor-pdf does not specify a fixed version the CI build fails right now.
Therefore this PR fixes it to 1.5.1.
