### PR TITLE
separate scheduled build from build on push and pull request …

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,11 +1,9 @@
-name: Build Master
+name: Nightly Build
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  # keep this separate from regular build, as GitHub will disable scheduled builds after 30 days
+  # without a change (and won't enable them automatically, for example on pushed changes or pull requests)
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
… to avoid issues due to automatically disabled scheduled builds

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[x] Build improvement

## Description

What is the goal of this pull request?
* GitHub seems to disable scheduled builds with the following message: "This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days." When then a pull request occurs or a change is pushed to the repo, the build is disabled and will not run.

How does it achieve that?
* Separate the scheduled build from the build on push/pull request

Are there any alternative ways to implement this?
* not that I am aware of

Are there any implications of this pull request? Anything a user must know?
* no change for the users. Maintainers need to keep two workflow files in sync.

## Issue

If this PR fixes an open issue, please add a line of the form:

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
(none that I can think of)