### PR TITLE
change URLs in POM as this artifact has moved to its own GitHub …

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Thank you for opening a pull request and contributing to AsciidoctorJ!
+Thank you for opening a pull request and contributing to AsciidoctorJ PDF!
 
 Please take a bit of time giving some details about your pull request:
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -17,10 +17,10 @@ def projectMeta = {
     }
     issueManagement {
         system 'github'
-        url 'https://github.com/asciidoctor/asciidoctorj/issues'
+        url 'https://github.com/asciidoctor/asciidoctorj-pdf/issues'
     }
     scm {
-        url 'https://github.com/asciidoctor/asciidoctorj'
+        url 'https://github.com/asciidoctor/asciidoctorj-pdf'
     }
     developers {
         developer {


### PR DESCRIPTION
… repository.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[x] Build improvement

## Description

What is the goal of this pull request?
* I noticed that dependabot reported a wrong changelog when it opened a pull request on one of my repositories. Looking a bit closer I noticed that the URLs in the pom.xml included in the artifact's JAR still point to an old repository.

How does it achieve that?
* this PR fixes the URLs.

Are there any alternative ways to implement this?
* no

Are there any implications of this pull request? Anything a user must know?
* users will not notice the change in their day-to-day work.

## Issue

If this PR fixes an open issue, please add a line of the form:


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
(none)