### PR TITLE
enable and fix upstream build

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -35,8 +35,8 @@ jobs:
           ./gradlew -S -Pskip.signing assemble
           ./gradlew -S -Pskip.signing check
       - name: Upstream Build
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
         run: |
-          test-asciidoctor-upstream.sh
+          ./test-asciidoctor-upstream.sh
 
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -24,9 +24,8 @@ jobs:
             java: '1.8'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - name: Fetch Sources
+        uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
@@ -34,9 +33,3 @@ jobs:
         run: |
           ./gradlew -S -Pskip.signing assemble
           ./gradlew -S -Pskip.signing check
-      - name: Upstream Build
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
-        run: |
-          ./test-asciidoctor-upstream.sh
-
-

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,8 +33,8 @@ jobs:
           ./gradlew -S -Pskip.signing assemble
           ./gradlew -S -Pskip.signing check
       - name: Upstream Build
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
         run: |
-          test-asciidoctor-upstream.sh
+          ./test-asciidoctor-upstream.sh
 
 

--- a/.github/workflows/upstream.yaml
+++ b/.github/workflows/upstream.yaml
@@ -1,9 +1,13 @@
-name: Nightly Build
+name: Upstream Build
 on:
-  # keep this separate from upstream build, as GitHub will disable scheduled builds after 30 days
+  # keep this separate from nightly build, as GitHub will disable scheduled builds after 30 days
   # without a change (and won't enable them automatically, for example on pushed changes or pull requests)
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -18,3 +22,5 @@ jobs:
       - name: Upstream Build
         run: |
           ./test-asciidoctor-upstream.sh
+
+

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   testCompile "org.jruby:jruby-complete:$jrubyVersion"
 
 
-  gems("rubygems:asciidoctor-pdf:1.5.4") {
+  gems("rubygems:asciidoctor-pdf:$asciidoctorPdfGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
     exclude module: 'thread_safe'

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ ext {
   // gem versions
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '1.5.8.1'
   asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : project(':asciidoctorj-pdf').version.replace('-', '.')
+
   groovyVersion = '2.1.8'
 
   addressableVersion = '2.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   commonsioVersion = '2.4'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
-  jrubyVersion = '9.1.17.0'
+  jrubyVersion = '9.2.17.0'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'
   xmlMatchersVersion = '1.0-RC1'
@@ -48,7 +48,7 @@ ext {
 
   addressableVersion = '2.4.0'
   public_suffixVersion = '1.4.6'
-  prawnGemVersion='2.2.2'
+  prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.2.2'
   rghostGemVersion = '0.9.7'
   rougeGemVersion = '3.26.0'
   spockVersion = '0.7-groovy-2.0'

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -1,27 +1,33 @@
 #!/bin/bash
+# shell script will fail if any command in this script fails
+set -e
+# shell script will fail if any command in a pipe will fail
+set -o pipefail
+# show all executed commands in log
+set -x
 
 # This script runs the AsciidoctorJ tests against the specified tag (or master) of the Asciidoctor Ruby gem.
 
 GRADLE_CMD=./gradlew
 # to build against a tag, set TAG to a git tag name (e.g., v1.5.2)
-TAG_PDF=master
-if [ "$TAG_PDF" == "master" ]; then
-  SRC_DIR_PDF=asciidoctor-pdf-master
+TAG_PDF=main
+if [ "${TAG_PDF}" == "main" ]; then
+  SRC_DIR_PDF=asciidoctor-pdf-main
 else
   SRC_DIR_PDF=asciidoctor-pdf-${TAG_PDF#v}
 fi
 rm -rf build/maven-pdf && mkdir -p build/maven-pdf && cd build/maven-pdf
-wget --quiet -O $SRC_DIR_PDF.zip https://github.com/asciidoctor/asciidoctor-pdf/archive/$TAG_PDF.zip
-unzip -q $SRC_DIR_PDF.zip
-cp ../../asciidoctor-pdf-gem-installer.pom $SRC_DIR_PDF/pom.xml
-cd $SRC_DIR_PDF
-ASCIIDOCTOR_PDF_VERSION=`grep 'VERSION' ./lib/asciidoctor-pdf/version.rb | sed "s/.*'\(.*\)'.*/\1/"`
+wget -O ${SRC_DIR_PDF}.zip https://github.com/asciidoctor/asciidoctor-pdf/archive/${TAG_PDF}.zip
+unzip -q ${SRC_DIR_PDF}.zip
+cp ../../asciidoctor-pdf-gem-installer.pom ${SRC_DIR_PDF}/pom.xml
+cd ${SRC_DIR_PDF}
+ASCIIDOCTOR_PDF_VERSION=$(grep 'VERSION' ./lib/asciidoctor/pdf/version.rb | sed "s/.*'\(.*\)'.*/\1/")
 sed "s;<version></version>;<version>$ASCIIDOCTOR_PDF_VERSION</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
 sed "s;^ *s\.files *.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor-pdf.gemspec > asciidoctor-pdf.gemspec.sedtmp && mv -f asciidoctor-pdf.gemspec.sedtmp asciidoctor-pdf.gemspec
-mvn install -Dgemspec=asciidoctor-pdf.gemspec
+mvn install -B -X -Dgemspec=asciidoctor-pdf.gemspec
 cd ../..
 #rm -rf build/maven-pdf
 cd ..
 
-$GRADLE_CMD -S -Pskip.signing -PasciidoctorGemVersion=$ASCIIDOCTOR_VERSION -PasciidoctorPdfGemVersion=$ASCIIDOCTOR_PDF_VERSION -PuseMavenLocal=true :asciidoctorj-pdf:clean :asciidoctorj-pdf:check
+$GRADLE_CMD -S -Pskip.signing -PasciidoctorGemVersion=${ASCIIDOCTOR_VERSION} -PasciidoctorPdfGemVersion=${ASCIIDOCTOR_PDF_VERSION} -PuseMavenLocal=true :asciidoctorj-pdf:clean :asciidoctorj-pdf:check
 exit $?

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -24,10 +24,14 @@ cd ${SRC_DIR_PDF}
 ASCIIDOCTOR_PDF_VERSION=$(grep 'VERSION' ./lib/asciidoctor/pdf/version.rb | sed "s/.*'\(.*\)'.*/\1/")
 sed "s;<version></version>;<version>$ASCIIDOCTOR_PDF_VERSION</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
 sed "s;^ *s\.files *.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor-pdf.gemspec > asciidoctor-pdf.gemspec.sedtmp && mv -f asciidoctor-pdf.gemspec.sedtmp asciidoctor-pdf.gemspec
-mvn install -B -X -Dgemspec=asciidoctor-pdf.gemspec
+mvn install -B -Dgemspec=asciidoctor-pdf.gemspec
 cd ../..
 #rm -rf build/maven-pdf
 cd ..
 
-$GRADLE_CMD -S -Pskip.signing -PasciidoctorGemVersion=${ASCIIDOCTOR_VERSION} -PasciidoctorPdfGemVersion=${ASCIIDOCTOR_PDF_VERSION} -PuseMavenLocal=true :asciidoctorj-pdf:clean :asciidoctorj-pdf:check
+$GRADLE_CMD -S -Pskip.signing -PasciidoctorJVersion=${ASCIIDOCTORJ_VERSION:-2.4.3} \
+                              -PasciidoctorPdfGemVersion=${ASCIIDOCTOR_PDF_VERSION} \
+                              -PprawnGemVersion=${PRAWN_VERSION:-2.4.0} \
+                              -PuseMavenLocal=true \
+                              :asciidoctorj-pdf:clean :asciidoctorj-pdf:check
 exit $?


### PR DESCRIPTION
I found that the upstream build is not triggered any more due to a mismatch of the condition. This PR also tries to fix what is broken in the build. 

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
Enable upstream build, and as a follow-up to tackle #40 

How does it achieve that?
Enable upstream build and see that shell script test-asciidoctor-upstream.sh runs without errors

Are there any alternative ways to implement this?
(maybe skip upstream build? don't know if that is an option)

Are there any implications of this pull request? Anything a user must know?
No

## Issue

(doesn't fix any issue)

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
