### PR TITLE
avoid now obsolete torquebox repository

### DIFF
--- a/asciidoctor-pdf-gem-installer.pom
+++ b/asciidoctor-pdf-gem-installer.pom
@@ -9,18 +9,6 @@
     <name>Asciidoctor PDF RubyGem Installer</name>
     <description>Installs the upstream Asciidoctor PDF RubyGem to the local repository.</description>
     <url>http://asciidoctor.org</url>
-    <repositories>
-        <repository>
-            <id>rubygems-releases</id>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>rubygems-releases</id>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
-        </pluginRepository>
-    </pluginRepositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -29,7 +17,7 @@
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.6</version>
+                <version>1.1.8</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -22,7 +22,7 @@ unzip -q ${SRC_DIR_PDF}.zip
 cp ../../asciidoctor-pdf-gem-installer.pom ${SRC_DIR_PDF}/pom.xml
 cd ${SRC_DIR_PDF}
 ASCIIDOCTOR_PDF_VERSION=$(grep 'VERSION' ./lib/asciidoctor/pdf/version.rb | sed "s/.*'\(.*\)'.*/\1/")
-sed "s;<version></version>;<version>$ASCIIDOCTOR_PDF_VERSION</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
+sed "s;<version></version>;<version>$ASCIIDOCTOR_PDF_VERSION-SNAPSHOT</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
 sed "s;^ *s\.files *.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor-pdf.gemspec > asciidoctor-pdf.gemspec.sedtmp && mv -f asciidoctor-pdf.gemspec.sedtmp asciidoctor-pdf.gemspec
 mvn install -B -Dgemspec=asciidoctor-pdf.gemspec
 cd ../..
@@ -30,7 +30,7 @@ cd ../..
 cd ..
 
 $GRADLE_CMD -S -Pskip.signing -PasciidoctorJVersion=${ASCIIDOCTORJ_VERSION:-2.4.3} \
-                              -PasciidoctorPdfGemVersion=${ASCIIDOCTOR_PDF_VERSION} \
+                              -PasciidoctorPdfGemVersion=${ASCIIDOCTOR_PDF_VERSION}-SNAPSHOT \
                               -PprawnGemVersion=${PRAWN_VERSION:-2.4.0} \
                               -PuseMavenLocal=true \
                               :asciidoctorj-pdf:clean :asciidoctorj-pdf:check


### PR DESCRIPTION
The latest version of gem-maven-plugin applies "SNAPSHOT" to all "-dev" ruby gem versions pom.xmls, therefore add it as well to the Maven version.

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
Avoid torquebox repo as described in #40

How does it achieve that?
By updating to the latest version of the `gem-maven-plugin`

Are there any alternative ways to implement this?
(not aware)

Are there any implications of this pull request? Anything a user must know?
No.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #40

## Release notes

(no CHANGELOG.adoc present in project)
