### PR TITLE
Fix inclusion of prawn-icon fonts

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -40,7 +40,7 @@ def gemFiles = fileTree("${project.buildDir}/.gems") {
   include "gems/prawn-*/data/*.txt"
   include "gems/prawn-*/data/encodings/*"
   // Include icon fonts
-  include "gems/prawn-icon-*/fonts/*/*"
+  include "gems/prawn-icon-*/data/fonts/**"
   // Include required data file from the addressable gem
   include "gems/addressable-*/data/*.data"
 


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ PDF!

Please take a bit of time giving some details about your pull request:

## Kind of change

[x] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

It looks like the location of the icon fonts inside prawn-icon changed in some version, or we always got it wrong.
Therefore at least the latest version of asciidoctorj-pdf does not contain the icon fonts from prawn-icon.
I cannot tell exactly what the consequences of this are, as icons seem to get rendered, however, we should probably still fix this as we always tried to include these files in the resulting jar.

Therefore this PR fixes the inclusion path so that the icon fonts also land in the jar.