### PR TITLE
update references to "Master" to be "Main"

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,4 +1,4 @@
-name: Build Master
+name: Build Main
 on:
   push:
     branches:

--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 {uri-repo}[AsciidoctorJ PDF] is a convenient repackaging of Asciidoctor PDF for use with {uri-asciidoctorj}[AsciidoctorJ], which brings the Asciidoctor ecosystem to the JVM.
 
 ifdef::badges[]
-image:https://github.com/asciidoctor/asciidoctorj-pdf/workflows/Build%20Master/badge.svg?event=push[Build Status (Github Actions)]
+image:https://github.com/asciidoctor/asciidoctorj-pdf/workflows/Build%20Main/badge.svg?event=push[Build Status (Github Actions)]
 endif::[]
 
 ifdef::awestruct,env-browser[]

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # show all executed commands in log
 set -x
 
-# This script runs the AsciidoctorJ tests against the specified tag (or master) of the Asciidoctor Ruby gem.
+# This script runs the AsciidoctorJ PDF tests against the specified tag (or main) of the Asciidoctor PDF Ruby gem.
 
 GRADLE_CMD=./gradlew
 # to build against a tag, set TAG to a git tag name (e.g., v1.5.2)


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ PDF!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
There are two references to "Master", while the default branch has been renamed to "Main". This PR tries to rectify this.

How does it achieve that?
Rename the name of the Build and its reference in the Readme.

Are there any alternative ways to implement this?
No

Are there any implications of this pull request? Anything a user must know?
No

A note the the maintainer: the new badge will be green only after the renamed Main build succeeded once.

## Issue

If this PR fixes an open issue, please add a line of the form:
-

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
