### PR TITLE
update to asciidoctor-pdf 1.6.0

### DIFF
--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
-version=1.5.4
+version=1.6.0
 gem_name=asciidoctor-pdf

--- a/build.gradle
+++ b/build.gradle
@@ -41,19 +41,19 @@ ext {
   pdfboxVersion = '1.8.16'
 
   // gem versions
-  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '1.5.8.1'
+  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.1'
   asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : project(':asciidoctorj-pdf').version.replace('-', '.')
 
   groovyVersion = '2.1.8'
 
   addressableVersion = '2.4.0'
   public_suffixVersion = '1.4.6'
-  prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.2.2'
+  prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
   rghostGemVersion = '0.9.7'
   rougeGemVersion = '3.26.0'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
-  ttfunkGemVersion = '1.5.1'
+  ttfunkGemVersion = '1.7.0'
   textHyphenVersion='1.4.1'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.5.4
+version=1.6.0
 sourceCompatibility=1.7
 targetCompatibility=1.7

--- a/itest/build.gradle
+++ b/itest/build.gradle
@@ -4,8 +4,9 @@ dependencies {
     exclude group:'org.jruby'
   }
 
+  testRuntime "org.jruby:jruby-complete:$jrubyVersion"
   testRuntime project(':asciidoctorj-pdf')
-  testRuntime 'org.asciidoctor:asciidoctorj-diagram:1.5.4'
+  testRuntime 'org.asciidoctor:asciidoctorj-diagram:2.1.2'
 }
 
 jar.enabled = false


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ PDF!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
This is a daring attempt to update to asciidoctor-pdf 1.6.0 and all related versions until the unit tests are green again.

How does it achieve that?
By updating asciidoctor-pdf and several pinned libraries that weren't compatible with Asciidoctor 2 any more

Are there any alternative ways to implement this?
Maybe some of the libraries (like ttfunk) could be un-pinned? Also the jruby-complete is pinned in the itest project, maybe that could be removed as well.

Are there any implications of this pull request? Anything a user must know?
As outlined in the [asciidoctor-pdf release notes](https://github.com/asciidoctor/asciidoctor-pdf/releases/tag/v1.6.0), this now requires Asciidoctor 2+ and JRuby 9.2+

## Issue

If this PR fixes an open issue, please add a line of the form:
-

## Release notes

> Please add a corresponding entry to the file CHANGELOG.adoc

There is currently no CHANGELOG.adoc file in the repository. Should one be added using the template of the asciidoctorj repostiory? 