### PR TITLE
Fix concurrentRuby to 1.1.7

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -15,9 +15,11 @@ dependencies {
     exclude module: 'addressable'
     exclude module: 'public_suffix'
     exclude module: 'ttfunk'
+    exclude module: 'concurrent-ruby'
   }
+  gems "rubygems:concurrent-ruby:$concurrentRubyVersion"
   gems "rubygems:thread_safe:$threadSafeGemVersion"
-  
+
   gems "rubygems:prawn:$prawnGemVersion"
   gems "rubygems:rghost:$rghostGemVersion"
   gems "rubygems:rouge:$rougeGemVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
 
   groovyVersion = '2.1.8'
 
-  addressableVersion = '2.4.0'
+  addressableVersion = '2.7.0'
   concurrentRubyVersion = '1.1.7'
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ ext {
   groovyVersion = '2.1.8'
 
   addressableVersion = '2.4.0'
+  concurrentRubyVersion = '1.1.7'
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
   rghostGemVersion = '0.9.7'


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ PDF!

Please take a bit of time giving some details about your pull request:

## Kind of change

[x] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

What is the goal of this pull request?

After the upgrade of asciidoctor-pdf the problematic gem concurrent-ruby 1.1.8 made it into the jar which results in higher conversion times.
This PR tries to fix that.

How does it achieve that?

Like we did in AsciidoctorJ fix the version of concurrent-ruby to 1.1.7.

Are there any alternative ways to implement this?

Maybe a fix in JRuby or concurrent-ruby?
Nothing else that I see that we could do.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
