### PR TITLE
Bump asciidoctor-pdf gem to v1.6.1

### DIFF
--- a/.github/workflows/upstream.yaml
+++ b/.github/workflows/upstream.yaml
@@ -12,14 +12,21 @@ on:
 jobs:
   build:
     name: Build
+    strategy:
+      max-parallel: 2
+      matrix:
+        java:
+          - '8'
+          - '11'
+          - '17'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
       - name: Upstream Build
         run: |
           ./test-asciidoctor-upstream.sh

--- a/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
+++ b/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -33,7 +32,7 @@ public class WhenBackendIsPdf {
         File outputFile1 = new File(inputFile.getParentFile(), filename + ".pdf");
         removeFileIfItExists(outputFile1);
 
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
+        asciidoctor.convertFile(inputFile, Options.builder().backend("pdf").safe(SafeMode.UNSAFE).build());
 
         assertThat(outputFile1.exists(), is(true));
         ImageProcessor imageProcessor = new ImageProcessor();
@@ -49,7 +48,7 @@ public class WhenBackendIsPdf {
         File outputFile1 = new File(inputFile.getParentFile(), filename + ".pdf");
         removeFileIfItExists(outputFile1);
 
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
+        asciidoctor.convertFile(inputFile, Options.builder().backend("pdf").safe(SafeMode.UNSAFE).build());
 
         assertThat(outputFile1.exists(), is(true));
 
@@ -72,7 +71,7 @@ public class WhenBackendIsPdf {
         File outputFile1 = new File(inputFile.getParentFile(), filename + ".pdf");
         removeFileIfItExists(outputFile1);
 
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
+        asciidoctor.convertFile(inputFile, Options.builder().backend("pdf").safe(SafeMode.UNSAFE).build());
 
         assertThat(outputFile1.exists(), is(true));
 
@@ -89,7 +88,7 @@ public class WhenBackendIsPdf {
         File outputFile1 = new File(inputFile.getParentFile(), filename + ".pdf");
         removeFileIfItExists(outputFile1);
 
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
+        asciidoctor.convertFile(inputFile, Options.builder().backend("pdf").safe(SafeMode.UNSAFE).build());
 
         assertThat(outputFile1.exists(), is(true));
 

--- a/asciidoctorj-pdf/src/test/java/org/asciidoctor/util/pdf/ImageProcessor.java
+++ b/asciidoctorj-pdf/src/test/java/org/asciidoctor/util/pdf/ImageProcessor.java
@@ -31,7 +31,7 @@ public class ImageProcessor extends PDFStreamEngine {
     private static final String INVOKE_OPERATOR = "Do";
 
     private int currentPage = 0;
-    private List<Image> images = new ArrayList<Image>();
+    private List<Image> images = new ArrayList<>();
 
     /**
      * Default constructor
@@ -79,7 +79,7 @@ public class ImageProcessor extends PDFStreamEngine {
         if (INVOKE_OPERATOR.equals(operation)) {
             COSName objectName = (COSName)arguments.get( 0 );
             Map<String, PDXObject> xobjects = getResources().getXObjects();
-            PDXObject xobject = (PDXObject)xobjects.get( objectName.getName() );
+            PDXObject xobject = xobjects.get( objectName.getName() );
 
             if (xobject instanceof PDXObjectImage)  {
                 PDXObjectImage image = (PDXObjectImage)xobject;
@@ -133,7 +133,7 @@ public class ImageProcessor extends PDFStreamEngine {
                 processSubStream( page, pdResources, invoke );
                 
                 // restore the graphics state
-                setGraphicsState( (PDGraphicsState)getGraphicsStack().pop() );
+                setGraphicsState( getGraphicsStack().pop() );
             }
         } else {
             super.processOperator( operator, arguments );

--- a/build.gradle
+++ b/build.gradle
@@ -33,22 +33,16 @@ ext {
   // jar versions
   arquillianVersion = '1.1.10.Final'
   arquillianSpockVersion = '1.0.0.Beta3'
-  commonsioVersion = '2.4'
-  guavaVersion = '18.0'
   jrubyVersion = '9.2.17.0'
-  saxonVersion = '9.5.1-6'
-  xmlMatchersVersion = '1.0-RC1'
   pdfboxVersion = '1.8.16'
   junitVersion = '4.13.2'
   hamcrestVersion = '2.2'
 
   // gem versions
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.2'
-  asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : project(':asciidoctorj-pdf').version.replace('-', '.')
+  asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '1.6.1'
 
-  groovyVersion = '2.1.8'
-
-  addressableVersion = '2.7.0'
+  addressableVersion = '2.8.0'
   concurrentRubyVersion = '1.1.7'
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
@@ -100,10 +94,6 @@ subprojects {
   dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
-    testImplementation("org.spockframework:spock-core:$spockVersion") {
-      exclude group: 'org.hamcrest', module: 'hamcrest-core'
-    }
-    testImplementation "org.codehaus.groovy:groovy-all:$groovyVersion"
     testImplementation "org.jboss.arquillian.junit:arquillian-junit-container:$arquillianVersion"
     testImplementation "org.jboss.arquillian.spock:arquillian-spock-container:$arquillianSpockVersion"
   }

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -29,7 +29,7 @@ cd ../..
 #rm -rf build/maven-pdf
 cd ..
 
-$GRADLE_CMD -S -Pskip.signing -PasciidoctorJVersion=${ASCIIDOCTORJ_VERSION:-2.4.3} \
+$GRADLE_CMD -S -Pskip.signing -PasciidoctorJVersion=${ASCIIDOCTORJ_VERSION:-2.5.2} \
                               -PasciidoctorPdfGemVersion=${ASCIIDOCTOR_PDF_VERSION}-SNAPSHOT \
                               -PprawnGemVersion=${PRAWN_VERSION:-2.4.0} \
                               -PuseMavenLocal=true \


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[x] Build improvement

## Description

*What is the goal of this pull request?*

Bump asciidoctor-pdf gem to latest v1.6.1
Also
* Remove some code warnings
* Remove unused build properties
* Bump addressableVersion to align with asciidoctor-pdf dependencies

*How does it achieve that?*

Sets the default value in `build.gradle` with `asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '1.6.1'`

*Are there any alternative ways to implement this?*

Yes. The original method read the value from the root `gradle.properties` file. I changed it to:
* Decouple the project version from the asciidoctor-pdf gem version.
* Follow AsciidoctorJ conventions (see https://github.com/asciidoctor/asciidoctorj/blob/6dd9015aa0611c99582e98a2db95314879376196/build.gradle#L82).

*Are there any implications of this pull request? Anything a user must know?*

There's still some version confusion (at least to me) because there are 2 version properties in 2 build.gradle files. If the root file is just for aggregation and only 1 jar is deployed from submodule `asciidoctorj-pdf`, I think we should remove the version from the root file.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
