### PR TITLE
Upgrade asciidoctor-pdf to 1.6.2

### DIFF
--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
-version=1.6.0
+version=1.6.2
 gem_name=asciidoctor-pdf

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
   rghostGemVersion = '0.9.7'
-  rougeGemVersion = '3.26.0'
+  rougeGemVersion = '3.27.0'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
 
   // gem versions
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.2'
-  asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '1.6.1'
+  asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '1.6.2'
 
   addressableVersion = '2.8.0'
   concurrentRubyVersion = '1.1.7'
@@ -74,12 +74,20 @@ subprojects {
 
   plugins.withType(JavaPlugin) {
     project.tasks.withType(JavaCompile) { task ->
-      task.sourceCompatibility = project.sourceCompatibility
-      task.targetCompatibility = project.targetCompatibility
+      if (JavaVersion.current().isJava11Compatible()) {
+        task.options.release = 8
+      }
+      if (project.hasProperty("showDeprecation")) {
+        options.compilerArgs << "-Xlint:deprecation"
+      }
+      if (project.hasProperty("showUnchecked")) {
+        options.compilerArgs << "-Xlint:unchecked"
+      }
     }
     project.tasks.withType(GroovyCompile) { task ->
-      task.sourceCompatibility = project.sourceCompatibility
-      task.targetCompatibility = project.targetCompatibility
+      if (JavaVersion.current().isJava11Compatible()) {
+        task.options.release = 8
+      }
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.6.0
+version=1.6.2
 sourceCompatibility=1.8
 targetCompatibility=1.8


### PR DESCRIPTION
Just upgrades asciidoctor-pdf to 1.6.2.

A preview with this PR is available for testing from the maven repo https://oss.sonatype.org/content/repositories/orgasciidoctor-1283/