### PR TITLE
Remove 'rouge' gem, already provided by AsciidoctorJ

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,9 +20,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        exclude:
-          - os: macos-latest
-            java: '8'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Fetch Sources
@@ -60,4 +57,4 @@ jobs:
         shell: cmd
         run: |
           gradlew.bat -S -Pskip.signing assemble
-          gradlew -S -Pskip.signing check
+          gradlew.bat -S -Pskip.signing check

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
-        uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: Upstream Build
         run: |

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,18 @@
+= AsciidoctorJ PDF Changelog
+:url-asciidoctor: http://asciidoctor.org
+:url-asciidoc: {url-asciidoctor}/docs/what-is-asciidoc
+:url-repo: https://github.com/asciidoctor/asciidoctorj-pdf
+:icons: font
+:star: icon:star[role=red]
+ifndef::icons[]
+:star: &#9733;
+endif::[]
+
+This document provides a high-level view of the changes introduced in AsciidoctorJ PDF by release.
+For a detailed view of what has changed, refer to the {url-repo}/commits/main[commit history] on GitHub.
+
+== Unreleased
+
+Improvement::
+
+* Remove 'rouge' gem, already provided by AsciidoctorJ (#87) (@abelsromero)

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -21,7 +21,6 @@ dependencies {
 
   gems "rubygems:prawn:$prawnGemVersion"
   gems "rubygems:rghost:$rghostGemVersion"
-  gems "rubygems:rouge:$rougeGemVersion"
   gems "rubygems:addressable:$addressableVersion"
   gems "rubygems:public_suffix:$public_suffixVersion"
   gems "rubygems:text-hyphen:$textHyphenVersion"
@@ -45,8 +44,6 @@ def gemFiles = fileTree("${project.buildDir}/.gems") {
   include "gems/prawn-icon-*/data/fonts/**"
   // Include required data file from the addressable gem
   include "gems/addressable-*/data/*.data"
-
-  exclude 'gems/rouge-*/lib/rouge/demos/**'
 }
 
 jrubyPrepare {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ ext {
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
   rghostGemVersion = '0.9.7'
-  rougeGemVersion = '3.30.0'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.7.0'


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[x] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

*What is the goal of this pull request?*
Remove 'rouge' gem, already provided by AsciidoctorJ.
It also enables Java 8 for macos and adds CHANGELOG.

*How does it achieve that?*
Simply removing the dependency the gem is not packaged in the jar.

*Are there any alternative ways to implement this?*
No

*Are there any implications of this pull request? Anything a user must know?*
Not that  I am aware.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #87 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
