### PR TITLE
Asciidoctor-PDF 2.3.20

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -1,3 +1,18 @@
+apply plugin: 'org.ysb33r.jruby.base'
+apply plugin: 'org.ysb33r.jruby.resolver'
+
+import org.ysb33r.gradle.jruby.api.base.tasks.JRubyPrepare
+
+repositories {
+    ruby.gems()
+}
+
+configurations {
+    runtimeGems {
+        canBeResolved(true)
+    }
+}
+
 dependencies {
   testImplementation ("org.asciidoctor:asciidoctorj:$asciidoctorJVersion") {
     exclude group:'org.jruby'
@@ -6,7 +21,7 @@ dependencies {
   testImplementation "org.jruby:jruby-complete:$jrubyVersion"
 
 
-  gems("rubygems:asciidoctor-pdf:$asciidoctorPdfGemVersion") {
+  runtimeGems("rubygems:asciidoctor-pdf:$asciidoctorPdfGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
     exclude module: 'thread_safe'
@@ -17,17 +32,18 @@ dependencies {
     exclude module: 'ttfunk'
     exclude module: 'concurrent-ruby'
   }
-  gems "rubygems:concurrent-ruby:$concurrentRubyVersion"
-  gems "rubygems:thread_safe:$threadSafeGemVersion"
+  runtimeGems "rubygems:concurrent-ruby:$concurrentRubyVersion"
+  runtimeGems "rubygems:thread_safe:$threadSafeGemVersion"
 
-  gems "rubygems:prawn:$prawnGemVersion"
-  gems "rubygems:prawn-svg:$prawnSvgGemVersion"
-  gems "rubygems:rghost:$rghostGemVersion"
-  gems "rubygems:addressable:$addressableVersion"
-  gems "rubygems:public_suffix:$public_suffixVersion"
-  gems "rubygems:text-hyphen:$textHyphenVersion"
-  gems "rubygems:ttfunk:$ttfunkGemVersion"
-  gems "rubygems:css_parser:$cssParserGemVersion"
+  runtimeGems "rubygems:afm:$afmGemVersion"
+  runtimeGems "rubygems:prawn:$prawnGemVersion"
+  runtimeGems "rubygems:prawn-svg:$prawnSvgGemVersion"
+  runtimeGems "rubygems:rghost:$rghostGemVersion"
+  runtimeGems "rubygems:addressable:$addressableVersion"
+  runtimeGems "rubygems:public_suffix:$public_suffixVersion"
+  runtimeGems "rubygems:text-hyphen:$textHyphenVersion"
+  runtimeGems "rubygems:ttfunk:$ttfunkGemVersion"
+  runtimeGems "rubygems:css_parser:$cssParserGemVersion"
 
   testImplementation "org.apache.pdfbox:pdfbox:$pdfboxVersion"
 }
@@ -48,13 +64,19 @@ def gemFiles = fileTree("${project.buildDir}/.gems") {
   include "gems/addressable-*/data/*.data"
 }
 
-jrubyPrepare {
-  doLast {
-    copy { // bundles the gems inside this artifact
-      from gemFiles
-      into preparedGems
+tasks.named('gemPrepare', JRubyPrepare) {
+    gemConfiguration = configurations.runtimeGems
+    doLast {
+        copy { // bundles the gems inside this artifact
+            from gemFiles
+            into preparedGems
+        }
     }
-  }
+}
+
+ext {
+    // path to use for the prepared jruby gems
+    preparedGems = new File("$buildDir/preparedGems")
 }
 
 ext.publicationName = "mavenAsciidoctorJPdf"

--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
-version=2.3.19
+version=2.3.20
 gem_name=asciidoctor-pdf

--- a/build.gradle
+++ b/build.gradle
@@ -40,18 +40,18 @@ ext {
 
   // gem versions
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.7'
-  asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '2.3.19'
+  asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '2.3.20'
 
   afmGemVersion = '0.2.2'
   addressableVersion = '2.8.0'
-  concurrentRubyVersion = '1.1.7'
+  concurrentRubyVersion = '1.3.5'
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
   prawnSvgGemVersion = "0.34.1"
   rghostGemVersion = '0.9.7'
   threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.7.0'
-  cssParserGemVersion = '1.13.0'
+  cssParserGemVersion = '1.21.1'
   textHyphenVersion='1.4.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 // modern plugins config
 plugins {
   id "signing"
-  id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+  id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
 
   id 'org.ysb33r.jruby.resolver'    version '2.0.0'
   id 'org.ysb33r.jruby.base' version '2.0.0'
@@ -175,13 +175,14 @@ configure(subprojects.findAll { it.name != 'itest'}) {
 nexusPublishing {
   repositories {
     sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
       if (project.hasProperty("sonatypeUsername")) {
         username = project.sonatypeUsername
       }
       if (project.hasProperty("sonatypePassword")) {
         password = project.sonatypePassword
       }
-      repositoryDescription = "Release ${project.group} ${project.version}"
     }
   }
   clientTimeout = Duration.ofMinutes(5)

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
   concurrentRubyVersion = '1.3.5'
   public_suffixVersion = '1.4.6'
   prawnGemVersion=project.hasProperty('prawnGemVersion') ? project.prawnGemVersion : '2.4.0'
-  prawnSvgGemVersion = "0.34.1"
+  prawnSvgGemVersion = "0.34.2"
   rghostGemVersion = '0.9.7'
   threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -12,19 +12,15 @@ buildscript {
     mavenCentral()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
   }
-  dependencies {
-    classpath("com.github.jruby-gradle:jruby-gradle-plugin:2.0.1") {
-      exclude module: 'grolifant'
-      exclude module: 'okhttp-digest'
-    }
-    classpath 'org.ysb33r.gradle:grolifant:0.17.0'
-  }
 }
 
 // modern plugins config
 plugins {
   id "signing"
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+
+  id 'org.ysb33r.jruby.resolver'    version '2.0.0'
+  id 'org.ysb33r.jruby.base' version '2.0.0'
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version
@@ -37,7 +33,7 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
-  jrubyVersion = '9.4.8.0'
+  jrubyVersion = '9.4.14.0'
   pdfboxVersion = '3.0.0'
   junitVersion = '5.10.0'
   assertjVersion = '3.24.2'
@@ -46,6 +42,7 @@ ext {
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.7'
   asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : '2.3.19'
 
+  afmGemVersion = '0.2.2'
   addressableVersion = '2.8.0'
   concurrentRubyVersion = '1.1.7'
   public_suffixVersion = '1.4.6'
@@ -54,7 +51,7 @@ ext {
   rghostGemVersion = '0.9.7'
   threadSafeGemVersion = '0.3.6'
   ttfunkGemVersion = '1.7.0'
-  cssParserGemVersion = '1.12.0'
+  cssParserGemVersion = '1.13.0'
   textHyphenVersion='1.4.1'
 }
 
@@ -137,12 +134,6 @@ subprojects {
 configure(subprojects.findAll {it.name != 'itest'}) {
   apply from: rootProject.file('gradle/versioncheck.gradle')
 
-  apply plugin: 'com.github.jruby-gradle.base'
-
-  repositories {
-    ruby.gems()
-  }
-
   if (JavaVersion.current().isJava8Compatible()) {
     javadoc {
       // Oracle JDK8 likes to fail the build over spoiled HTML
@@ -163,7 +154,7 @@ configure(subprojects.findAll {it.name != 'itest'}) {
   sourceSets {
     main {
       //let's register an output folder on the main SourceSet:
-      output.dir(preparedGems, builtBy: 'jrubyPrepare')
+      output.dir(preparedGems, builtBy: 'gemPrepare')
       //it is now a part of the 'main' classpath and will be a part of the jar
     }
   }
@@ -179,10 +170,6 @@ configure(subprojects.findAll { it.name != 'itest'}) {
   compileJava {
     options.release = 8
   }
-
-  // QUESTION is this the right place to insert this task dependency in the lifecycle?
-  // IMPORTANT The TMP or TEMP environment variable must be set for the gem install command to work on Windows
-  processResources.dependsOn jrubyPrepare
 }
 
 nexusPublishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.19
+version=2.3.20
 sourceCompatibility=1.8
 targetCompatibility=1.8
 


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[x] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

What is the goal of this pull request?

This PR upgrades asciidoctor-pdf to 2.3.20.
As part of that we need to migrate to the new jruby-gradle plugin, and migrate publishing to central.sonatype.com, or rather its compatibility API.

